### PR TITLE
chore: Adding go.wasmcloud.dev/runtime-operator

### DIFF
--- a/docs/runtime-operator/index.html
+++ b/docs/runtime-operator/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <meta
+      name="go-import"
+      content="go.wasmcloud.dev/runtime-operator git https://github.com/wasmCloud/runtime-operator"
+    />
+  </head>
+</html>


### PR DESCRIPTION
New repo at https://github.com/wasmCloud/runtime-operator