### PR TITLE
docs: README with archival note for vanity URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # go-vanity-urls
 
-Hosts vanity URLs under go.wasmcloud.dev.
+> **_NOTE:_**  Archived. go vanity urls are now hosted in the [go repo](https://github.com/wasmCloud/go/tree/main/docs).
 
+Hosts vanity URLs under go.wasmcloud.dev.


### PR DESCRIPTION
Added a note about the archival status of vanity URLs.

